### PR TITLE
#169522676 add and test Add_entry endpoint with the use of database

### DIFF
--- a/Server/Controllers/entryController.js
+++ b/Server/Controllers/entryController.js
@@ -1,24 +1,21 @@
 import moment from 'moment';
 import checkOwner from '../helpers/checkOwner';
+import { querry } from '../db';
 
 class EntryClass {
     async createEntry(req, res) {
         const { title, description } = req.body;
-        const id = entries.length + 1;
         const createdBy = await req.tokenData.id;
         const createdOn = moment().format('LLL');
-        const newEntry = {
-            id, createdBy, createdOn, title, description,
-        };
-        entries.push(newEntry);
+        const insertQuery = 'INSERT INTO entries (createdby, createdon, title, description, editedOn) VALUES ($1, $2, $3, $4, $5) RETURNING *;';
+        const values = [createdBy, createdOn, title, description, createdOn];
+        const result = await querry(insertQuery, values);
+        const data = result[0];
         return res.status(201).json({
             status: 201,
+            message: 'Entry created successfully',
             data: {
-                message: 'Entry created successfully',
-                id,
-                createdOn,
-                title,
-                description,
+                data,
             },
         });
     }

--- a/Server/Routes/entryRoutes.js
+++ b/Server/Routes/entryRoutes.js
@@ -5,9 +5,9 @@ import { checkNewEntry } from '../middleware/checkNewEntry';
 import { validateEntryParams } from '../middleware/checkParams';
 
 const router = express.Router();
-router.post('/api/v1/entries', [checkToken, checkNewEntry], eClass.createEntry);
-router.patch('/api/v1/entries/:entryId', [checkToken, checkNewEntry, validateEntryParams], eClass.modifyEntry);
-router.delete('/api/v1/entries/:entryId', [checkToken, validateEntryParams], eClass.deleteEntry);
-router.get('/api/v1/entries', checkToken, eClass.getEntries);
-router.get('/api/v1/entries/:entryId', [checkToken, validateEntryParams], eClass.getSpecificEntry);
+router.post('/api/v2/entries', [checkToken, checkNewEntry], eClass.createEntry);
+router.patch('/api/v2/entries/:entryId', [checkToken, checkNewEntry, validateEntryParams], eClass.modifyEntry);
+router.delete('/api/v2/entries/:entryId', [checkToken, validateEntryParams], eClass.deleteEntry);
+router.get('/api/v2/entries', checkToken, eClass.getEntries);
+router.get('/api/v2/entries/:entryId', [checkToken, validateEntryParams], eClass.getSpecificEntry);
 export default router;

--- a/Server/Test/v_entryTests.js
+++ b/Server/Test/v_entryTests.js
@@ -16,25 +16,14 @@ describe('Create a new entry', () => {
             .end((err, res) => {
                 expect(res).to.have.status(201);
                 expect(res.body.data).to.be.a('object');
-                expect(res.body.data.message).to.equal('Entry created successfully');
-            });
-        done();
-    });
-    it('Should return a success: second entry created', (done) => {
-        chai.request(app).post('/api/v2/entries')
-            .set('Authorization', process.env.userToken2)
-            .send(testEntry[0])
-            .end((err, res) => {
-                expect(res).to.have.status(201);
-                expect(res.body.data).to.be.a('object');
-                expect(res.body.data.message).to.equal('Entry created successfully');
+                expect(res.body.message).to.equal('Entry created successfully');
             });
         done();
     });
     it('Should return an error: unauthorized access', (done) => {
         chai.request(app).post('/api/v2/entries')
             .set('Authorization', process.env.falseToken)
-            .send(testEntry[1])
+            .send(testEntry[0])
             .end((err, res) => {
                 expect(res).to.have.status(403);
                 expect(res.body).to.have.property('error');
@@ -71,6 +60,17 @@ describe('Create a new entry', () => {
             .end((err, res) => {
                 expect(res).to.have.status(401);
                 expect(res.body).to.have.property('error');
+            });
+        done();
+    });
+    it('Should return a success: second entry created', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.userToken2)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(201);
+                expect(res.body.data).to.be.a('object');
+                expect(res.body.message).to.equal('Entry created successfully');
             });
         done();
     });

--- a/Server/Test/v_entryTests.js
+++ b/Server/Test/v_entryTests.js
@@ -1,0 +1,77 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it } from 'mocha';
+import dotenv from 'dotenv';
+import app from '../../index';
+import testEntry from '../Model/mockData/testEntry';
+
+dotenv.config();
+const { expect } = chai;
+chai.use(chaiHttp);
+describe('Create a new entry', () => {
+    it('Should return a success: new entry created', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.userToken1)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(201);
+                expect(res.body.data).to.be.a('object');
+                expect(res.body.data.message).to.equal('Entry created successfully');
+            });
+        done();
+    });
+    it('Should return a success: second entry created', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.userToken2)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(201);
+                expect(res.body.data).to.be.a('object');
+                expect(res.body.data.message).to.equal('Entry created successfully');
+            });
+        done();
+    });
+    it('Should return an error: unauthorized access', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.falseToken)
+            .send(testEntry[1])
+            .end((err, res) => {
+                expect(res).to.have.status(403);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal('You are not authorized to perform this task');
+            });
+        done();
+    });
+    it('Should return an error: Invalid data', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.userToken1)
+            .send(testEntry[1])
+            .end((err, res) => {
+                expect(res).to.have.status(400);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal(' title  must be a string');
+            });
+        done();
+    });
+    it('Should return an error: Token is not provided', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', '')
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(401);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal('Token not provided');
+            });
+        done();
+    });
+    it('Should return an error: Bad token', (done) => {
+        chai.request(app).post('/api/v2/entries')
+            .set('Authorization', process.env.falseToken2)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(401);
+                expect(res.body).to.have.property('error');
+            });
+        done();
+    });
+});

--- a/Server/middleware/checkToken.js
+++ b/Server/middleware/checkToken.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
+import { querry } from '../db/index';
 
 dotenv.config();
 export const checkToken = async (req, res, next) => {
@@ -13,8 +14,10 @@ export const checkToken = async (req, res, next) => {
     try {
         const verified = jwt.verify(authorization, process.env.secret);
         req.tokenData = verified;
-        const userFound = await users.find(user => user.id === req.tokenData.id);
-        if (!userFound) {
+        const selectQuery = 'SELECT * FROM users WHERE id=$1';
+        const value = [req.tokenData.id];
+        const userFound = await querry(selectQuery, value);
+        if (!userFound[0]) {
             return res.status(403).json({
                 status: 403,
                 error: 'You are not authorized to perform this task',


### PR DESCRIPTION


[Finishes]
#### What does this PR do?
This PR adds and tests the `Add entry` endpoint with the use of database

#### Description of Task to be completed
>-add an entry into the database after checking if the user is authorized to do so
>-tests add entry endpoint for all possibilities

#### How should this be manually tested?
>- clone the repo
>- run `npm install` and `npm run dev` to start the server
>- use either postman or any other testing tool to see if `post`  `http://localhost:4000/api/v2/entries` works
>- run `npm test` to see if the tests are passing
>- Check if the Travis test are passing

#### What are the relevant pivotal tracker stories?
#169522676

#### Screenshots (if appropriate)
![Screenshot (106)](https://user-images.githubusercontent.com/50268181/68088116-7aaf3c00-fe64-11e9-82fa-3375606c4151.png)
![Screenshot (107)](https://user-images.githubusercontent.com/50268181/68088117-7aaf3c00-fe64-11e9-8276-dc7c75c002ff.png)
![Screenshot (108)](https://user-images.githubusercontent.com/50268181/68088118-7aaf3c00-fe64-11e9-95ca-abc14e077436.png)
![Screenshot (109)](https://user-images.githubusercontent.com/50268181/68088119-7b47d280-fe64-11e9-9fd2-20f340447da3.png)
