### PR TITLE
#169523276 add and test modify entry endpoint with the use of database

### DIFF
--- a/Server/Controllers/entryController.js
+++ b/Server/Controllers/entryController.js
@@ -23,21 +23,20 @@ class EntryClass {
     async modifyEntry(req, res) {
         const id = parseInt(req.params.entryId, 10);
         const { title, description } = req.body;
-        const entryFound = await entries.find(entry => entry.id === id && checkOwner(req, entry.createdBy));
-        if (entryFound) {
+        const selectQuerry = 'SELECT * FROM entries WHERE id=$1';
+        const entryFound = await querry(selectQuerry, [id]);
+        if (entryFound[0] && checkOwner(req, entryFound[0].createdby)) {
             const editedOn = moment().format('LLL');
+            const updateQuery = 'UPDATE entries SET title=$1, description=$2, editedOn=$3 WHERE id =$4 RETURNING *;';
+            const values = [title, description, editedOn, id];
+            const data = await querry(updateQuery, values);
             entryFound.title = title;
             entryFound.description = description;
             entryFound.editedOn = editedOn;
             return res.status(200).json({
                 status: 200,
-                data: {
-                    message: 'Entry successfully edited',
-                    id,
-                    title,
-                    description,
-                    editedOn,
-                },
+                message: 'Entry successfully edited',
+                data: data[0],
             });
         } return res.status(404).json({
             status: 404,

--- a/Server/Test/v_entryTests.js
+++ b/Server/Test/v_entryTests.js
@@ -75,3 +75,50 @@ describe('Create a new entry', () => {
         done();
     });
 });
+describe('Modify an entry', () => {
+    it('Should return a success: entry successfully edited', (done) => {
+        chai.request(app).patch(`/api/v2/entries/${testEntry[3].entryId}`)
+            .set('Authorization', process.env.userToken1)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(200);
+                expect(res.body.data).to.be.a('object');
+                expect(res.body).to.have.property('data');
+                expect(res.body.message).to.equal('Entry successfully edited');
+                done();
+            });
+    });
+    it('Should return an error: entry not found', (done) => {
+        chai.request(app).patch(`/api/v2/entries/${testEntry[5].entryId}`)
+            .set('Authorization', process.env.userToken1)
+            .send(testEntry[2])
+            .end((err, res) => {
+                expect(res).to.have.status(404);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal('Entry not found');
+                done();
+            });
+    });
+    it('Should return an error: this entry is not yours', (done) => {
+        chai.request(app).patch(`/api/v2/entries/${testEntry[3].entryId}`)
+            .set('Authorization', process.env.userToken2)
+            .send(testEntry[2])
+            .end((err, res) => {
+                expect(res).to.have.status(404);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal('Entry not found');
+                done();
+            });
+    });
+    it('Should not return a success: Invalid params', (done) => {
+        chai.request(app).patch(`/api/v2/entries/${testEntry[4].entryId}`)
+            .set('Authorization', process.env.userToken1)
+            .send(testEntry[0])
+            .end((err, res) => {
+                expect(res).to.have.status(400);
+                expect(res.body).to.have.property('error');
+                expect(res.body.error).to.equal(' entryId  must be a positive number');
+                done();
+            });
+    });
+});

--- a/Server/middleware/checkNewEntry.js
+++ b/Server/middleware/checkNewEntry.js
@@ -3,7 +3,7 @@ import validationHelper from '../helpers/validationHelper';
 
 export const checkNewEntry = (req, res, next) => {
     const createEntrySchema = Joi.object().keys({
-        title: Joi.string().min(3).max(20).required(),
+        title: Joi.string().min(3).max(50).required(),
         description: Joi.string().min(3).required(),
     });
     const schemasValidation = Joi.validate(req.body, createEntrySchema);


### PR DESCRIPTION
#### What does this PR do?
This PR updates modify entry endpoint to use the database instead of data Structure

#### Description of Task to be completed
>- modify an entry from the database after checking if the user is authorized to do so
>- this endpoint for all possibilities

#### How should this be manually tested?
>- clone the repo
>- run `npm install` and `npm run dev` to start the server
>- use either postman or any other testing tool to see if `patch`  `http://localhost:4000/api/v2/entries/entryId` works
>- run `npm test` to see if the tests are passing
>- Check if the Travis test are passing

#### What are the relevant pivotal tracker stories?
#169523276

#### Screenshots (if appropriate)
![Screenshot (110)](https://user-images.githubusercontent.com/50268181/68089074-fa8dd400-fe6d-11e9-9071-837744b6e52a.png)
![Screenshot (111)](https://user-images.githubusercontent.com/50268181/68089075-fa8dd400-fe6d-11e9-8e12-252de75be9c5.png)
